### PR TITLE
Use jakarta.json and eclipse parsson

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,17 +20,25 @@ data from JSON Strings or files in parameterized tests.
 ### Apache Maven
 
 ```xml
-<dependency>
-    <groupId>net.joshka</groupId>
-    <artifactId>junit-json-params</artifactId>
-    <version>5.9.2-r0</version>
-</dependency>
+<dependencies>
+    <dependency>
+        <groupId>net.joshka</groupId>
+        <artifactId>junit-json-params</artifactId>
+        <version>5.9.2-r1</version>
+    </dependency>
+    <dependency>
+        <groupId>org.eclipse.parsson</groupId>
+        <artifactId>parsson</artifactId>
+        <version>1.1.1</version>
+    </dependency>
+</dependencies>
 ```
 
 ### Gradle
 
 ```groovy
-compile 'net.joshka:junit-json-params:5.9.2-r0'
+testImplementation 'net.joshka:junit-json-params:5.9.2-r0'
+testImplementation 'org.eclipse.parsson:parsson:1.1.1'
 ```
 
 ## Examples

--- a/build.gradle
+++ b/build.gradle
@@ -33,7 +33,13 @@ dependencies {
     api platform('org.junit:junit-bom:5.9.2')
     api 'org.junit.jupiter:junit-jupiter-api'
     api 'org.junit.jupiter:junit-jupiter-params'
-    api 'jakarta.json:jakarta.json-api:2.1.1'
+
+    // jakarta.json-api is not exposed on any public members, so does not need
+    // to be exposed to use the library
+    implementation 'jakarta.json:jakarta.json-api:2.1.1'
+
+    // this is the reference implementation of jakarta.json, a consumer of this
+    // library needs to bring their own version (probably this)
     testImplementation 'org.eclipse.parsson:parsson:1.1.1'
     testImplementation 'org.junit.jupiter:junit-jupiter-engine'
     testImplementation 'org.assertj:assertj-core:3.24.2'

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = 'net.joshka'
-version = '5.9.2-r0'
+version = '5.9.2-r1'
 ext.isReleaseVersion = !version.endsWith("SNAPSHOT")
 ext.isRunningOnTravis = System.getenv("CI") == "true"
 
@@ -33,8 +33,8 @@ dependencies {
     api platform('org.junit:junit-bom:5.9.2')
     api 'org.junit.jupiter:junit-jupiter-api'
     api 'org.junit.jupiter:junit-jupiter-params'
-    api 'javax.json:javax.json-api:1.1.4'
-    testImplementation 'org.glassfish:javax.json:1.1.4'
+    api 'jakarta.json:jakarta.json-api:2.1.1'
+    testImplementation 'org.eclipse.parsson:parsson:1.1.1'
     testImplementation 'org.junit.jupiter:junit-jupiter-engine'
     testImplementation 'org.assertj:assertj-core:3.24.2'
     testImplementation 'org.mockito:mockito-core:5.1.1'

--- a/src/main/java/net/joshka/junit/json/params/JsonArgumentsProvider.java
+++ b/src/main/java/net/joshka/junit/json/params/JsonArgumentsProvider.java
@@ -5,11 +5,11 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.ArgumentsProvider;
 import org.junit.jupiter.params.support.AnnotationConsumer;
 
-import javax.json.Json;
-import javax.json.JsonReader;
-import javax.json.JsonStructure;
-import javax.json.JsonValue;
-import javax.json.stream.JsonParsingException;
+import jakarta.json.Json;
+import jakarta.json.JsonReader;
+import jakarta.json.JsonStructure;
+import jakarta.json.JsonValue;
+import jakarta.json.stream.JsonParsingException;
 import java.io.IOException;
 import java.io.Reader;
 import java.io.StringReader;

--- a/src/main/java/net/joshka/junit/json/params/JsonConverter.java
+++ b/src/main/java/net/joshka/junit/json/params/JsonConverter.java
@@ -4,7 +4,7 @@ import org.junit.jupiter.api.extension.ParameterContext;
 import org.junit.jupiter.params.converter.ArgumentConversionException;
 import org.junit.jupiter.params.converter.ArgumentConverter;
 
-import javax.json.JsonObject;
+import jakarta.json.JsonObject;
 
 public class JsonConverter implements ArgumentConverter {
 

--- a/src/main/java/net/joshka/junit/json/params/JsonFileArgumentsProvider.java
+++ b/src/main/java/net/joshka/junit/json/params/JsonFileArgumentsProvider.java
@@ -6,10 +6,10 @@ import org.junit.jupiter.params.provider.ArgumentsProvider;
 import org.junit.jupiter.params.support.AnnotationConsumer;
 import org.junit.platform.commons.util.Preconditions;
 
-import javax.json.Json;
-import javax.json.JsonReader;
-import javax.json.JsonValue;
-import javax.json.JsonValue.ValueType;
+import jakarta.json.Json;
+import jakarta.json.JsonReader;
+import jakarta.json.JsonValue;
+import jakarta.json.JsonValue.ValueType;
 import java.io.InputStream;
 import java.util.List;
 import java.util.function.BiFunction;

--- a/src/test/java/net/joshka/junit/json/params/JsonArgumentsProviderTest.java
+++ b/src/test/java/net/joshka/junit/json/params/JsonArgumentsProviderTest.java
@@ -4,10 +4,10 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 
-import javax.json.JsonNumber;
-import javax.json.JsonObject;
-import javax.json.JsonString;
-import javax.json.stream.JsonParsingException;
+import jakarta.json.JsonNumber;
+import jakarta.json.JsonObject;
+import jakarta.json.JsonString;
+import jakarta.json.stream.JsonParsingException;
 import java.lang.annotation.Annotation;
 
 import static org.assertj.core.api.Assertions.*;

--- a/src/test/java/net/joshka/junit/json/params/JsonFileArgumentsProviderTest.java
+++ b/src/test/java/net/joshka/junit/json/params/JsonFileArgumentsProviderTest.java
@@ -1,16 +1,16 @@
 package net.joshka.junit.json.params;
 
 import java.util.List;
-import javax.json.JsonArray;
+import jakarta.json.JsonArray;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.platform.commons.PreconditionViolationException;
 
-import javax.json.JsonNumber;
-import javax.json.JsonObject;
-import javax.json.JsonString;
+import jakarta.json.JsonNumber;
+import jakarta.json.JsonObject;
+import jakarta.json.JsonString;
 import java.io.InputStream;
 import java.util.function.BiFunction;
 


### PR DESCRIPTION
- https://projects.eclipse.org/projects/ee4j.jsonp
- https://projects.eclipse.org/projects/ee4j.parsson

[Mark jakarta.json as implementation dep](https://github.com/joshka/junit-json-params/pull/131/commits/f30596c9ceba8a7cb340e78b0ba31364cadeb3c0)

This is used internally, so it shouldn't need to be exposed to the caller.
However it's likely that the caller still needs to bring their own
implementation.

Use org.eclipse.parsson:parsson:1.1.1 unless you have other preferences.